### PR TITLE
Add config toggles to restrict deposit/restock use to GUI screens

### DIFF
--- a/src/main/java/net/p3pp3rf1y/sophisticateditemactions/Config.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticateditemactions/Config.java
@@ -18,11 +18,13 @@ public class Config {
 
 	public static class Client {
 		public final DiscoveryNudges discoveryNudges;
+		public final KeybindSettings keybindSettings;
 
 		public Client(ModConfigSpec.Builder builder) {
 			builder.comment("Client-side Settings").push("client");
 
 			discoveryNudges = new DiscoveryNudges(builder);
+			keybindSettings = new KeybindSettings(builder);
 
 			builder.pop();
 		}
@@ -68,6 +70,18 @@ public class Config {
 			depositEnabled = builder.comment("Whether deposit hint can be shown").define("depositEnabled", true);
 			checkIntervalTicks = builder.comment("How often to evaluate nudge state in ticks").defineInRange("checkIntervalTicks", 40, 1, Integer.MAX_VALUE);
 			debugLogging = builder.comment("Logs nudge state transitions to debug log").define("debugLogging", false);
+
+			builder.pop();
+		}
+	}
+
+	public static class KeybindSettings {
+		public final ModConfigSpec.BooleanValue depositOnlyInGUI;
+
+		public KeybindSettings(ModConfigSpec.Builder builder) {
+			builder.comment("Client configuration for keybind behavior").push("keybindSettings");
+
+			depositOnlyInGUI = builder.comment("Whether deposit key should be enabled only in GUIs").define("depositOnlyInGUI", false);
 
 			builder.pop();
 		}

--- a/src/main/java/net/p3pp3rf1y/sophisticateditemactions/Config.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticateditemactions/Config.java
@@ -77,11 +77,13 @@ public class Config {
 
 	public static class KeybindSettings {
 		public final ModConfigSpec.BooleanValue depositOnlyInGUI;
+		public final ModConfigSpec.BooleanValue restockOnlyInGUI;
 
 		public KeybindSettings(ModConfigSpec.Builder builder) {
 			builder.comment("Client configuration for keybind behavior").push("keybindSettings");
 
 			depositOnlyInGUI = builder.comment("Whether deposit key should be enabled only in GUIs").define("depositOnlyInGUI", false);
+			restockOnlyInGUI = builder.comment("Whether restock key should be enabled only in GUIs").define("restockOnlyInGUI", false);
 
 			builder.pop();
 		}

--- a/src/main/java/net/p3pp3rf1y/sophisticateditemactions/client/ClientEventHandler.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticateditemactions/client/ClientEventHandler.java
@@ -205,7 +205,7 @@ public class ClientEventHandler {
 		boolean fillEmpty = (mods & GLFW.GLFW_MOD_CONTROL) != 0;
 
 		Screen screen = Minecraft.getInstance().screen;
-		if (keybindSettings.restockOnlyInGUI.get() && !(screen instanceof AbstractContainerScreen<?>)) {
+		if (keybindSettings.restockOnlyInGUI.get() && screen != null) {
 			return false;
 		}
 		ItemStack filter = ItemStack.EMPTY;

--- a/src/main/java/net/p3pp3rf1y/sophisticateditemactions/client/ClientEventHandler.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticateditemactions/client/ClientEventHandler.java
@@ -205,6 +205,9 @@ public class ClientEventHandler {
 		boolean fillEmpty = (mods & GLFW.GLFW_MOD_CONTROL) != 0;
 
 		Screen screen = Minecraft.getInstance().screen;
+		if (keybindSettings.restockOnlyInGUI.get() && !(screen instanceof AbstractContainerScreen<?>)) {
+			return false;
+		}
 		ItemStack filter = ItemStack.EMPTY;
 		int slot = -1;
 		boolean refillSingle = false;

--- a/src/main/java/net/p3pp3rf1y/sophisticateditemactions/client/ClientEventHandler.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticateditemactions/client/ClientEventHandler.java
@@ -16,6 +16,8 @@ import net.neoforged.neoforge.client.event.*;
 import net.neoforged.neoforge.client.gui.VanillaGuiLayers;
 import net.neoforged.neoforge.client.settings.IKeyConflictContext;
 import net.neoforged.neoforge.common.NeoForge;
+import net.p3pp3rf1y.sophisticateditemactions.Config;
+import net.p3pp3rf1y.sophisticateditemactions.Config.KeybindSettings;
 import net.p3pp3rf1y.sophisticateditemactions.SophisticatedItemActions;
 import net.p3pp3rf1y.sophisticateditemactions.client.discovery.ItemActionNudgeManager;
 import net.p3pp3rf1y.sophisticateditemactions.client.discovery.NudgeActionUsageTracker;
@@ -49,6 +51,7 @@ public class ClientEventHandler {
 			KEYBIND_SOPHISTICATEDITEMACTIONS_CATEGORY);
 	private static final List<IHoveredStackProvider> HOVERED_STACK_PROVIDERS = new ArrayList<>();
 	private static final ItemActionNudgeManager NUDGE_MANAGER = new ItemActionNudgeManager();
+	private static final KeybindSettings keybindSettings = Config.CLIENT.keybindSettings;
 	private static final IHoveredStackProvider DEFAULT_HOVERED_STACK_PROVIDER = new IHoveredStackProvider() {
 		@Override
 		public ItemStack getHoveredStack(Screen screen) {
@@ -267,6 +270,10 @@ public class ClientEventHandler {
 			return false;
 		}
 
+		
+		if (keybindSettings.depositOnlyInGUI.get()) {
+			return false;
+		}
 		return tryDepositItem(player, onlyMatching);
 	}
 

--- a/src/main/java/net/p3pp3rf1y/sophisticateditemactions/client/ClientEventHandler.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticateditemactions/client/ClientEventHandler.java
@@ -205,7 +205,7 @@ public class ClientEventHandler {
 		boolean fillEmpty = (mods & GLFW.GLFW_MOD_CONTROL) != 0;
 
 		Screen screen = Minecraft.getInstance().screen;
-		if (keybindSettings.restockOnlyInGUI.get() && screen != null) {
+		if (keybindSettings.restockOnlyInGUI.get() && screen == null) {
 			return false;
 		}
 		ItemStack filter = ItemStack.EMPTY;

--- a/src/main/resources/assets/sophisticateditemactions/lang/en_us.json
+++ b/src/main/resources/assets/sophisticateditemactions/lang/en_us.json
@@ -41,5 +41,6 @@
   "sophisticateditemactions.configuration.checkIntervalTicks": "Check Interval",
   "sophisticateditemactions.configuration.debugLogging": "Debug Logging",
   "sophisticateditemactions.configuration.keybindSettings": "Keybind Settings",
-  "sophisticateditemactions.configuration.depositOnlyInGUI": "Only allow depositing while a GUI is open"
+  "sophisticateditemactions.configuration.depositOnlyInGUI": "Only allow depositing while a GUI is open",
+  "sophisticateditemactions.configuration.restockOnlyInGUI": "Only allow restocking while a GUI is open"
 }

--- a/src/main/resources/assets/sophisticateditemactions/lang/en_us.json
+++ b/src/main/resources/assets/sophisticateditemactions/lang/en_us.json
@@ -39,5 +39,7 @@
   "sophisticateditemactions.configuration.restockEnabled": "Enable Restock Nudge",
   "sophisticateditemactions.configuration.depositEnabled": "Enable Deposit Nudge",
   "sophisticateditemactions.configuration.checkIntervalTicks": "Check Interval",
-  "sophisticateditemactions.configuration.debugLogging": "Debug Logging"
+  "sophisticateditemactions.configuration.debugLogging": "Debug Logging",
+  "sophisticateditemactions.configuration.keybindSettings": "Keybind Settings",
+  "sophisticateditemactions.configuration.depositOnlyInGUI": "Only allow depositing while a GUI is open"
 }


### PR DESCRIPTION
## Changes
- Add a section to the mod config called KeybindSettings
  - One toggle for the "Deposit Item" action
  - A second toggle for the "Restock Item" action

The default values for both of those options align with the current default behavior. Changing either to the "ON" state will prevent the respective action from triggering in-world. This allows a player to overlap the binds for these actions on keys that are free when a GUI is open, e.g. _W_ moves forward in-world, and deposits the hovered item to nearby storage in-GUI.

## Testing
- Deposit only in GUIs
  - Bind your deposit action to a movement key like W
  - Confirm that W will move the character AND deposit the held item
  - The same applies for modifiers, ctrl/shift/alt+w each deposit as expected while still moving forward
  - Enable the "Deposit only in GUIs" config option
  - Confirm that W does not trigger the deposit action while in-world
  - With an inventory or chest open, confirm that W triggers deposit on the hovered item (or mainInventory / hotbar with modifier)
- Restock only in GUIs
  - Bind your restock action to a movement key like D
  - Confirm that D will move the character AND restock the held item
  - Same applies for modifiers, shift/alt+d restock the inventory or hotbar while moving
  - Enable the "Restock only in GUIs" config option
  - Confirm that D does not trigger the restock option while in-world
  - With an inventory open, confirm that D triggers restock on the hovered item (or mainInventory / hotbar with modifier)
  - With a recipe open, confirm that D triggers restock on the hovered ingredient

This PR resolves #8